### PR TITLE
Add trivy scanning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,15 @@ pipeline {
       }
     }
 
+    stage('Scan Docker image') {
+      steps{
+        script {
+          TAG = sh(returnStdout: true, script: 'cat VERSION')
+        }
+        scanAndReport("demo-app:${TAG}", "NONE")
+      }
+    }
+
     stage('Publish Docker image to registry') {
       when {
         branch 'master'


### PR DESCRIPTION
Since we persist the Docker image after the build, we should scan that image. This PR adds that scanning, set to not fail the build at the moment to prevent interfering with day to day work. A subsequent issue will be created to fix the failures and turn on failing when new vulns are encountered. 

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>