### PR TITLE
fix: disable ssl for mysql test

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -27,10 +27,9 @@ services:
       interval: 10s
       retries: 10
     environment:
-      MYSQL_ROOT_PASSWORD: yourStrong()Password
       MYSQL_DATABASE: mysql
-    volumes:
-    - ./test.sql:/docker-entrypoint-initdb.d/test.sql
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: yourStrong()Password
 
   mssql:
     image: mcr.microsoft.com/mssql/server:2017-latest

--- a/test/test
+++ b/test/test
@@ -14,7 +14,7 @@ postgres) export DB_PLATFORM=postgres
           export DB_USERNAME=postgres
           ;;
 mysql)  export DB_PLATFORM=mysql
-        export DB_URL=mysql://mysql:3306/mysql
+        export DB_URL=mysql://mysql:3306/mysql?useSSL=false
         export DB_USERNAME=mysql
         ;;
 mssql)  export DB_PLATFORM=mssql

--- a/test/test.sql
+++ b/test/test.sql
@@ -1,2 +1,0 @@
-GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' IDENTIFIED BY 'yourStrong()Password';
-GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'%' IDENTIFIED BY 'yourStrong()Password';


### PR DESCRIPTION
The mysql tests fail when ssl is used (which the default). The failure is to do with failure to verify a self-signed certificate. The fix is to simply disable ssl in the test case, which loses nothing.