### PR TITLE
Update Spring Boot to 2.5.3 to address multiple high & critical security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4-1206-jdbc42</version>
+      <version>42.2.23</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.3.0.RELEASE</version>
+      <version>2.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.16</version>
+      <version>8.0.20</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.3.0.RELEASE</version>
+      <version>2.5.3</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -48,7 +48,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
-  </dependencies>
+ </dependencies>
 
   <properties>
     <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.10.RELEASE</version>
+    <version>2.2.3.RELEASE</version>
   </parent>
 
   <dependencies>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.0</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.0.RELEASE</version>
+    <version>2.5.3</version>
   </parent>
 
   <dependencies>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>7.4.1.jre11</version>
+      <version>9.2.1.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.2.3.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -35,6 +36,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <version>2.2.3.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.3.RELEASE</version>
+    <version>2.3.0.RELEASE</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.2.3.RELEASE</version>
+      <version>2.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -27,6 +27,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
+      <version>8.0.16</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
@@ -36,7 +37,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.2.3.RELEASE</version>
+      <version>2.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hello/controller/PetController.java
+++ b/src/main/java/hello/controller/PetController.java
@@ -23,7 +23,7 @@ class PetController {
 
   @GetMapping("/{id}")
   ResponseEntity<Pet> getPet(@PathVariable Long id) {
-      Pet pet = repository.findOne(id);
+      Pet pet = repository.findById(id).orElseThrow();
       if (pet == null) {
         return ResponseEntity.notFound().build();
       }
@@ -47,7 +47,7 @@ class PetController {
 
   @DeleteMapping("/{id}")
   ResponseEntity<?> deletePet(@PathVariable Long id) {
-    Pet pet = repository.findOne(id);
+    Pet pet = repository.findById(id).orElseThrow();
     if (pet == null) {
       return ResponseEntity.notFound().build();
     }


### PR DESCRIPTION
This PR addresses ~60 issues that privy was flagging in the build process. Addressing those issues required updating Spring Framework from the 1.5.10 version we were using up to 2.5.3.  That required a code change - findOne became findById and needed an "OrElseThrow()" method call.  I also had to add an explicit dependency since the javax.validators.* are no longer implicitly included in the Spring web starter. This PR should probably be squashed and merged.