### PR TITLE
Fixes rule for when to publish image to DockerHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,11 @@ pipeline {
 
     stage('Publish Docker image to registry') {
       when {
-        branch 'main'
+        // Only run this stage when it's a tag build matching vA.B.C
+        tag(
+          pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+\$",
+          comparator: "REGEXP"
+        )
       }
 
       steps {

--- a/bin/publish
+++ b/bin/publish
@@ -7,17 +7,8 @@ readonly REGISTRY="${1:-cyberark}"
 readonly IMAGE_NAME="demo-app"
 readonly IMAGE_TAG="$(cat VERSION)"
 
-# fetching tags is required for git_description to work
-git fetch --tags
-git_description=$(git describe --tags)
+docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${REGISTRY}/${IMAGE_NAME}:latest"
 
-# only publish images when the tag matches the VERSION
-if [ "$git_description" = "v${IMAGE_TAG}" ]; then
-  echo "Revision $git_description matches version $VERSION exactly. Pushing to Dockerhub..."
-
-  docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
-  docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${REGISTRY}/${IMAGE_NAME}:latest"
-
-  docker push "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
-  docker push "${REGISTRY}/${IMAGE_NAME}:latest"
-fi
+docker push "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+docker push "${REGISTRY}/${IMAGE_NAME}:latest"


### PR DESCRIPTION
Currently, the checks for whether to publish or not in Jenkins is
looking for the branch name for a commit to be "main", and then there's
a check for `git description --tags` returning a perfect semver tag.

This check is broken, since pushes with tagged versions will have
a branch name being the version tag (e.g. `v1.2.0`), rather than
having a branch name of `main`.

The fix is to check for the branch name being a version tag (i.e. a
`v` followed by a semver version number, e.g. `v1.2.0`). This check
is added to the Jenkinsfile, so we can eliminate any conditionals/checking of
branches/tags in `bin/publish` (i.e. that script publishes
unconditionally).