### PR TITLE
Update ruby & JDK base images, maven packages & vscode problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # STAGE:
 # Fetch summon
 
-FROM ruby:2.4 as summon
+FROM ruby:2.5 as summon
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl
@@ -17,7 +17,7 @@ RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.s
 
 # STAGE:
 # The 'maven' base is used to package the application
-FROM maven:3.6.3-jdk-11-slim as maven
+FROM maven:3.8.4-openjdk-11-slim as maven
 
 WORKDIR /app
 
@@ -35,8 +35,8 @@ RUN mvn package && cp target/petstore-*.jar app.jar
 # This base is used for the final image
 # It extracts the packaged application from the previous stage
 # and builds the final image
-FROM openjdk:11-jre-slim
-MAINTAINER CyberArk
+FROM openjdk:11-jdk-slim
+LABEL org.opencontainers.image.authors="CyberArk"
 
 COPY --from=summon /usr/local/lib/summon /usr/local/lib/summon
 COPY --from=summon /usr/local/bin/summon /usr/local/bin/summon

--- a/pom.xml
+++ b/pom.xml
@@ -10,34 +10,34 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.3</version>
+    <version>2.6.2</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.5.3</version>
+      <version>2.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.23</version>
+      <version>42.3.1</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.20</version>
+      <version>8.0.28</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>9.2.1.jre11</version>
+      <version>9.4.1.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.5.3</version>
+      <version>2.6.2</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
+      <version>2.6.2</version>
     </dependency>
  </dependencies>
 

--- a/src/main/java/hello/controller/PetController.java
+++ b/src/main/java/hello/controller/PetController.java
@@ -23,7 +23,7 @@ class PetController {
 
   @GetMapping("/{id}")
   ResponseEntity<Pet> getPet(@PathVariable Long id) {
-      Pet pet = repository.findById(id).orElseThrow();
+      Pet pet = repository.findById(id).orElseThrow(null);
       if (pet == null) {
         return ResponseEntity.notFound().build();
       }
@@ -47,7 +47,7 @@ class PetController {
 
   @DeleteMapping("/{id}")
   ResponseEntity<?> deletePet(@PathVariable Long id) {
-    Pet pet = repository.findById(id).orElseThrow();
+    Pet pet = repository.findById(id).orElseThrow(null);
     if (pet == null) {
       return ResponseEntity.notFound().build();
     }

--- a/src/main/java/hello/controller/VulnerableController.java
+++ b/src/main/java/hello/controller/VulnerableController.java
@@ -1,11 +1,8 @@
 package hello.controller;
 
-import java.net.URI;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 class VulnerableController {

--- a/src/main/java/hello/model/Pet.java
+++ b/src/main/java/hello/model/Pet.java
@@ -1,6 +1,5 @@
 package hello.model;
 
-import java.io.Serializable;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Id;


### PR DESCRIPTION
Updated versions in the Dockerfile and pom.xml to remove indirect dependency on log4j 2.14.1. While I was fixing things, VSCode was flagging some unused imports and a need to add a "null" argument to one method call, so I did those things too. 

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>