### PR TITLE
Update dep versions, add .trivyignore for CVE-2022-25857

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,17 @@
+# CVE-2022-25857
+# The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of 
+# Service (DoS) due missing to nested depth limitation for collections.
+#
+# org.yaml/snakeyaml is an indirect dependency we get from spring boot. A 
+# spring boot maintainer stated that "Most Sping Boot applications only need 
+# SnakeYaml to parse their own application.yml configuration. I don't
+# think we can consider this content as untrusted input." I take this to mean
+# we're likely not vulnerable to this issue. It should be fixed in Spring Boot
+# 2.7.4, which as of 9/15 is not yet released. Snyk will notify us when a fix
+# is available. At that time, we should remove this entry from the .trivyignore.
+CVE-2022-25857
+
+
 # CVE-2021-23840
 # Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow 
 # the output length argument in some cases where the input length is close to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Updated all dependency versions in pom.xml and added maven-enforcer-plugin
+  [conjurdemos/pet-store-demo#52](https://github.com/conjurdemos/pet-store-demo/pull/52)
 - Upgraded Postgres to 42.4.1 to resolve CVE-2022-31197
-  [conjurdemos/pet-store-demo#51](https://github.com/conjurdemos/pet-store-demo/pull/50)
+  [conjurdemos/pet-store-demo#51](https://github.com/conjurdemos/pet-store-demo/pull/51)
 - Upgraded Spring to 2.6.9
   [conjurdemos/pet-store-demo#49](https://github.com/conjurdemos/pet-store-demo/pull/49)
 - Upgraded Spring to 2.6.7 & Maven/Ruby containers to latest versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Security
 - Updated all dependency versions in pom.xml and added maven-enforcer-plugin
-  [conjurdemos/pet-store-demo#52](https://github.com/conjurdemos/pet-store-demo/pull/52)
+  [conjurdemos/pet-store-demo#54](https://github.com/conjurdemos/pet-store-demo/pull/54)
 - Upgraded Postgres to 42.4.1 to resolve CVE-2022-31197
   [conjurdemos/pet-store-demo#51](https://github.com/conjurdemos/pet-store-demo/pull/51)
 - Upgraded Spring to 2.6.9

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,13 @@
       <version>8.0.30</version>
     </dependency>
     <dependency>
+      <!-- TODO: Bumping this to 11.2.1.jre11 causes the MSSQL tests to 
+        fail. No error message was given, but it looks like it's a time out
+        issue. There's something in the major version updates that's breaking.
+        We need to investigate what that is. -->
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>11.2.1.jre11</version>
+      <version>9.4.1.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,47 +7,48 @@
   <artifactId>petstore</artifactId>
   <version>0.1.0</version>
 
+  <!-- TODO: When updating Spring Boot to 2.7.4 or higher, remove the entry for CVE-2022-25857 from .trivyignore -->
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.9</version>
+    <version>2.7.3</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.6.9</version>
+      <version>2.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.4.1</version>
+      <version>42.5.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
+      <version>8.0.30</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>9.4.1.jre11</version>
+      <version>11.2.1.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.6.9</version>
+      <version>2.7.3</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0-b180830.0359</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>2.6.9</version>
+      <version>2.7.3</version>
     </dependency>
  </dependencies>
 
@@ -61,6 +62,27 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+            <execution>
+                <id>enforce-maven</id>
+                <goals>
+                    <goal>enforce</goal>
+                </goals>
+                <configuration>
+                    <rules>
+                        <requireMavenVersion>
+                            <version>3.2.5</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
I wanted to update org.yaml/snakeyaml but that's an indirect dependency of spring boot. They won't have the updated snakeyaml version until their 2.7.4 release which isn't out as of this PR. So, I went ahead and updated all the dependency versions I could, and then added a .trivyignore entry for the snakeyaml CVE. 

Snyk scans will alert me when the 2.7.4 release is available. At that point, I'll update spring boot in the pom.xml and remove the .trivyignore entry. 

The Spring Boot maintainers do not believe that most of Spring Boot is vulnerable as the packages do not take user input - they only use SnakeYaml to parse their own application.yml configurations. See https://github.com/spring-projects/spring-boot/pull/32203#issuecomment-1233359475

I also added the maven-enforcer-plugin to make sure that a recent enough maven version is used to build the project to match the needs of the plugins we use. 

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>