### PR TITLE
Upgrade Spring Boot to 2.74, mysql connector to 8.0.31

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,17 +1,3 @@
-# CVE-2022-25857
-# The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of 
-# Service (DoS) due missing to nested depth limitation for collections.
-#
-# org.yaml/snakeyaml is an indirect dependency we get from spring boot. A 
-# spring boot maintainer stated that "Most Sping Boot applications only need 
-# SnakeYaml to parse their own application.yml configuration. I don't
-# think we can consider this content as untrusted input." I take this to mean
-# we're likely not vulnerable to this issue. It should be fixed in Spring Boot
-# 2.7.4, which as of 9/15 is not yet released. Snyk will notify us when a fix
-# is available. At that time, we should remove this entry from the .trivyignore.
-CVE-2022-25857
-
-
 # CVE-2021-23840
 # Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow 
 # the output length argument in some cases where the input length is close to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Updated Spring boot to 2.7.4 to pull in fixes for jackson-databind for
+  CVE-2022-42003 and CVE-2022-42004
+  [conjurdemos/pet-store-demo#55](https://github.com/conjurdemos/pet-store-demo/pull/55)
 - Updated all dependency versions in pom.xml and added maven-enforcer-plugin
   [conjurdemos/pet-store-demo#54](https://github.com/conjurdemos/pet-store-demo/pull/54)
 - Upgraded Postgres to 42.4.1 to resolve CVE-2022-31197

--- a/pom.xml
+++ b/pom.xml
@@ -7,18 +7,17 @@
   <artifactId>petstore</artifactId>
   <version>0.1.0</version>
 
-  <!-- TODO: When updating Spring Boot to 2.7.4 or higher, remove the entry for CVE-2022-25857 from .trivyignore -->
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -42,7 +41,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -52,7 +51,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
     </dependency>
  </dependencies>
 


### PR DESCRIPTION
Attempt to fix the Trivy failures by upgrading to Spring Boot 2.7.4. There are 2 CVEs in com.faster.jackson.databind: CVE-2022-42003 and CVE-2022-42004. This should definitely fix 42004. It might fix 42003, as well, but that depends on whether Spring automatically pulls in databind 2.13.4.2 or stays on 2.13.4.

I also removed an old .trivyignore entry that had a note in the POM to remove when we made this upgrade.

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>