### PR TITLE
Upgrade springboot and openjdk base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Updated Springboot to 3.0.2 and Dockerfile to openjdk:21
+  [conjurdemos/pet-store-demo#58](https://github.com/conjurdemos/pet-store-demo/pull/58)
 - Updated postgresql to 42.5.1 to resolve CVE-2022-41946
   [conjurdemos/pet-store-demo#57](https://github.com/conjurdemos/pet-store-demo/pull/57)
 - Updated Spring boot to 2.7.5 to pull in fixes for jackson-databind for

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.s
 
 # STAGE:
 # The 'maven' base is used to package the application
-FROM maven:3.8.5-openjdk-11-slim as maven
+FROM maven:3-openjdk-18-slim as maven
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN mvn package && cp target/petstore-*.jar app.jar
 # This base is used for the final image
 # It extracts the packaged application from the previous stage
 # and builds the final image
-FROM openjdk:11-jdk-slim
+FROM openjdk:21-slim
 LABEL org.opencontainers.image.authors="CyberArk"
 
 # Install the fix for CVE-2022-1271

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.5</version>
+    <version>3.0.2</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.7.5</version>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.7.5</version>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>2.7.5</version>
+      <version>3.0.2</version>
     </dependency>
  </dependencies>
 

--- a/src/main/java/hello/model/Pet.java
+++ b/src/main/java/hello/model/Pet.java
@@ -1,12 +1,12 @@
 package hello.model;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Id;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Column;
-import javax.validation.constraints.NotNull;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 @Table(name = "pet")


### PR DESCRIPTION
Dependency upgrades to address Snyk vulnerabilities

EE 8 APIs (javax.*) -> EE 9 APIs (jakarta.x)
See: https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0