### PR TITLE
Update docker compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Shifted tests to use `docker compose` instead of `docker-compose` 
+  [conjurdemos/pet-store-demo#70](https://github.com/conjurdemos/pet-store-demo/pull/70)
+
 ### Security
 - Upgrade spring-boot to 3.0.7 for CVE-2023-20883
   [conjurdemos/pet-store-demo#63](https://github.com/conjurdemos/pet-store-demo/pull/63)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [conjurdemos/pet-store-demo#70](https://github.com/conjurdemos/pet-store-demo/pull/70)
 
 ### Security
+- Upgrade spring-boot to 3.2.1 and Java to 11
+  [conjurdemos/pet-store-demo#70](https://github.com/conjurdemos/pet-store-demo/pull/70)
 - Upgrade spring-boot to 3.0.7 for CVE-2023-20883
   [conjurdemos/pet-store-demo#63](https://github.com/conjurdemos/pet-store-demo/pull/63)
 - Upgrade mysql-connector-java to v8.0.33

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.12</version>
+    <version>3.2.1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>3.0.12</version>
+      <version>3.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>3.0.12</version>
+      <version>3.2.1</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -47,12 +47,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>3.0.12</version>
+      <version>3.2.1</version>
     </dependency>
  </dependencies>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
   </properties>
 
   <build>

--- a/test/test
+++ b/test/test
@@ -29,7 +29,7 @@ esac
 cleanup () {
 # Uncomment this line for debugging
 #  docker-compose logs app;
-  docker-compose down -v;
+  docker compose down -v;
 }
 trap cleanup EXIT QUIT INT;
 
@@ -37,10 +37,10 @@ trap cleanup EXIT QUIT INT;
 COMPOSE_PROJECT_NAME="$(openssl rand -hex 3)"
 export COMPOSE_PROJECT_NAME
 
-docker-compose up -d ${DB_PLATFORM};
+docker compose up -d ${DB_PLATFORM};
 
 echo "Waiting for $DB_PLATFORM to start"
-while ! docker-compose ps ${DB_PLATFORM} | grep healthy > /dev/null 2>&1;
+while ! docker compose ps ${DB_PLATFORM} | grep healthy > /dev/null 2>&1;
   do
     >&2 printf '. '
     sleep 1
@@ -49,11 +49,11 @@ done
 echo ""
 >&2 echo "$DB_PLATFORM is up - continuing"
 
-docker-compose build test
-docker-compose up -d app test;
+docker compose build test
+docker compose up -d app test;
 
 echo "Waiting for app"
-docker-compose exec -T test timeout 200 bash -c "
+docker compose exec -T test timeout 200 bash -c "
 while ! curl -v app:8080 > /dev/null 2>&1;
 do
   >&2 printf '. '
@@ -67,9 +67,9 @@ echo ""
 echo ""
 echo 'Creating pet:'
 echo '{"name": "Mr. Init"}'
-docker-compose exec -T test curl -s -d '{"name": "Mr. Init"}' -H "Content-Type: application/json" app:8080/pet
+docker compose exec -T test curl -s -d '{"name": "Mr. Init"}' -H "Content-Type: application/json" app:8080/pet
 
 echo "Retrieving pet:"
-docker-compose exec -T test curl -s app:8080/pets
+docker compose exec -T test curl -s app:8080/pets
 echo ""
 echo ""


### PR DESCRIPTION
Changes the tests to use `docker compose` instead of `docker-compose` to reflect changes in Docker. That then exposed that Trivy was failing for a CVE in Spring Boot, so this PR also upgrades Spring Boot to 3.2.1. That change required bumping the Java version to Java 11.