### PR TITLE
Upgrade postgres & other dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Upgrade postgres connector to v42.7.2 for CVE-2023-1597, aa well as Spring Framework to 3.2.3, com.microsoft.sqlserver to 12.6.1, and maven enforcer to 3.4.1 [conjurdemos/pet-store-demo#74](https://github.com/conjurdemos/pet-store-demo/pull/74)
+
 ## [1.2.2] - 2024-02-09
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -10,19 +10,19 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>3.2.2</version>
+      <version>3.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.1</version>
+      <version>42.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>12.6.0.jre11</version>
+      <version>12.6.1.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>3.2.2</version>
+      <version>3.2.3</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>3.2.2</version>
+      <version>3.2.3</version>
     </dependency>
  </dependencies>
 
@@ -64,7 +64,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.4.1</version>
         <executions>
             <execution>
                 <id>enforce-maven</id>


### PR DESCRIPTION
The java postgres connector had CVE-2024-1597. I upgraded it and bumped the versions for the rest of the dependencies that had updates. 