### PR TITLE
CNJR-0000: Use alpine instead of Ruby base image, Upgrade spring boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Switch to alpine base image, upgrade Spring Boot to 3.3.1
+  [conjurdemos/pet-store-demo#77](https://github.com/conjurdemos/pet-store-demo/pull/77)
+
 ## [1.2.4] - 2024-03-22
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@
 # STAGE:
 # Fetch summon
 
-FROM ruby:3 as summon
+FROM alpine as summon
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl
+RUN apk add --no-cache curl bash
 
 # Install summon and summon-conjur
-RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.sh \
+RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash && \
-    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/master/install.sh \
+    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash
 
 # STAGE:

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.3.1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   app:
     image: demo-app:latest


### PR DESCRIPTION
There doesn't seem to be any real reason we're using the Ruby base image for the pet store app. The app is written in Java, and besides this container is for summon and we're installing the compiled version. The Ruby image is large and has therefore has a large attack surface and many packages with vulnerabilities. Switching to a slimmer base image such as Alpine reduces attack surface and vulnerabilities.

While we're at it, updating to the latest spring boot version.
Also removed deprecated "version" tag from docker-compose.yml.